### PR TITLE
Remove degree symbol from testcase comment.

### DIFF
--- a/src/test/java/frc/robot/subsystems/LimelightTest.java
+++ b/src/test/java/frc/robot/subsystems/LimelightTest.java
@@ -23,7 +23,7 @@ public class LimelightTest {
     double tH = 8.0f ; // target high hoop is 8 feet high.
     double mountAngle = degToRad(20.0f) ; // say mounted at 20 degrees.
     double offsetAngle = degToRad(25.0f) ; // as read from limelight.
-    // tan(20° + 25°) = 1, so this is just targetHeight - mountHeight
+    // tan(20 + 25) = 1, so this is just targetHeight - mountHeight
     Assert.assertEquals(
       expected, Limelight.distanceToTarget(mH, mountAngle, tH, offsetAngle), DELTA);
   }


### PR DESCRIPTION
I had used the degree symbol in a unit test comment.
That causes compilation to give errors like:

src/test/java/frc/robot/subsystems/LimelightTest.java:26:
    error: unmappable character (0xC2) for encoding US-ASCII
    // tan(20?? + 25??) = 1, so this is just targetHeight -
        mountHeight

There seem to be some ways to fix that by getting -encoding
passed to the compiler, but it wasn't immediately obvious
to me how you'd do that ing gradle, so just not worth
spending effort.