### PR TITLE
Update intake subsystem from robo7660.

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -7,15 +7,14 @@ package frc.robot;
 import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj.XboxController;
 import frc.robot.commands.DriveRobot;
+import frc.robot.commands.FrontIntake;
 import frc.robot.commands.ExampleCommand;
-import frc.robot.commands.RunIntake;
 import frc.robot.subsystems.Drive;
-import frc.robot.subsystems.ExampleSubsystem;
 import frc.robot.subsystems.Intake;
-import edu.wpi.first.wpilibj2.command.button.Button;
-import edu.wpi.first.wpilibj2.command.button.JoystickButton;
+import frc.robot.subsystems.ExampleSubsystem;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
 /**
  * This class is where the bulk of the robot should be declared. Since Command-based is a
@@ -32,8 +31,6 @@ public class RobotContainer {
   private XboxController controller1 = new XboxController(0);
   private XboxController controller2 = new XboxController(1);
 
-  private JoystickButton button1A = new JoystickButton(controller1, XboxController.Button.kA.value);
-
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   private RobotContainer() {
 
@@ -49,8 +46,10 @@ public class RobotContainer {
    * edu.wpi.first.wpilibj2.command.button.JoystickButton}.
    */
   private void configureButtonBindings() {
+    JoystickButton a = new JoystickButton(controller1, 1);
 
-    button1A.whileHeld(new RunIntake(m_intake));
+   //a.whileHeld(new FrontIntake(m_intake, 0.1));
+   a.whenPressed(new FrontIntake(m_intake, 0.1));
   }
 
   /**

--- a/src/main/java/frc/robot/commands/FrontIntake.java
+++ b/src/main/java/frc/robot/commands/FrontIntake.java
@@ -7,37 +7,55 @@ package frc.robot.commands;
 import frc.robot.subsystems.Intake;
 import edu.wpi.first.wpilibj2.command.CommandBase;
 
-
-public class RunIntake extends CommandBase {
-  
+/** An example command that uses an example subsystem. */
+public class FrontIntake extends CommandBase {
+  @SuppressWarnings({"PMD.UnusedPrivateField", "PMD.SingularField"})
   private final Intake m_subsystem;
+  private double m_speed = 0.0;
+  private long m_startTime = 0;
 
-
-  public RunIntake(Intake subsystem) {
+  /**
+   * Creates a new FrontIntake.
+   *
+   * @param subsystem The subsystem used by this command.
+   */
+  public FrontIntake(Intake subsystem) {
     m_subsystem = subsystem;
     // Use addRequirements() here to declare subsystem dependencies.
     addRequirements(subsystem);
+  }
+  public FrontIntake(Intake subsystem, double s) {
+    m_subsystem = subsystem;
+    // Use addRequirements() here to declare subsystem dependencies.
+    addRequirements(subsystem);
+    m_speed = s;
   }
 
   // Called when the command is initially scheduled.
   @Override
   public void initialize() {
-    m_subsystem.startIntake();
+    m_startTime = System.currentTimeMillis();
   }
 
   // Called every time the scheduler runs while the command is scheduled.
   @Override
-  public void execute() {}
+  public void execute() {
+    m_subsystem.setFront(m_speed);
+  }
 
   // Called once the command ends or is interrupted.
   @Override
   public void end(boolean interrupted) {
-    m_subsystem.stopIntake();
+    m_subsystem.setFront(0.0);
   }
 
   // Returns true when the command should end.
   @Override
   public boolean isFinished() {
-    return false;
+    if((System.currentTimeMillis() - m_startTime) < 3000){
+      return false;
+    } else {
+      return true;
+    }
   }
 }

--- a/src/main/java/frc/robot/subsystems/Intake.java
+++ b/src/main/java/frc/robot/subsystems/Intake.java
@@ -4,26 +4,18 @@
 
 package frc.robot.subsystems;
 
-import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
+import com.ctre.phoenix.motorcontrol.ControlMode;
+import com.ctre.phoenix.motorcontrol.can.TalonSRX;
 
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Intake extends SubsystemBase {
-  
-  public Intake(){
-  }
-
-  final WPI_TalonSRX intake = new WPI_TalonSRX(9);
-
-  public void startIntake(){
-
-    intake.set(0.5);
-  }
-
-  public void stopIntake(){
-    
-    intake.set(0);
-  }
+  private TalonSRX front = new TalonSRX(9);
+  private TalonSRX back = new TalonSRX(5);
+  double frontSpeed = 0.0;
+  double backSpeed = 0.0;
+  /** Creates a new ExampleSubsystem. */
+  public Intake() {}
 
   @Override
   public void periodic() {
@@ -33,5 +25,9 @@ public class Intake extends SubsystemBase {
   @Override
   public void simulationPeriodic() {
     // This method will be called once per scheduler run during simulation
+  }
+  public void setFront(double s){
+    frontSpeed = s;
+    front.set(ControlMode.PercentOutput, frontSpeed);
   }
 }


### PR DESCRIPTION
This pulls in the Intake Subsystem that was worked on Saturday.
There are a couple differences from that which was in main:

 * RunIntake is now FrontIntake : this seems better named given
   our current expectation of how the intake will work.

 * The Intake subsystem is now exposing speed for the motor.
   I'm not sure how I feel about this.  If we expect that there
   is only one speed that we will run the FrontIntake motor at,
   then it seems to me better to not expose that to a caller.

   The previous version simply had startIntake and stopIntake.
   This has setFront(double).  The first seems more correct if
   there is only a single "correct speed".

 * command attached to whileHeld to whenPressed.
   It feels to me like whileHeld is correct here.

   whileHeld schedules a command repteadly while trigger is active and
   cancels it when trigger released.  If it finishes while held it
   is rescheduled.

   whenHeld schedules once and cancels when released.  It is not
   rescheduled if the command finishes when still being held.

   So whileHeld seems more correct here, allowing the driver to
   keep it running even if the sensor stopped it (possibly to
   get another ball)

Co-Authored-By: Incredibilyintelligennntindividual <98365710+Incredibilyintelligennntindividual@users.noreply.github.com>