### PR TITLE
Disable attempt to use Limelight from Drive.

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -40,7 +40,7 @@ public class Drive extends SubsystemBase {
     // This method will be called once per scheduler run
     SmartDashboard.putNumber("Left Velocity", leftEncoder.getVelocity());
     SmartDashboard.putNumber("Right Velocity", rightEncoder.getVelocity());
-    SmartDashboard.putNumber("LimeLight", Limelight.d());
+    // SmartDashboard.putNumber("LimeLight", Limelight.d());
   }
 
   @Override


### PR DESCRIPTION
This was causing stacktrace in simulation as there was no limelight.