### PR TITLE
Set subsystem names to display them in shuffleboard in Test mode.

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -66,6 +66,15 @@ public class RobotContainer {
         m_limelight = new LimelightSim();
     }
 
+    // setting Name allows subsystems to be displayed in shuffleboard when robot is in Test mode.
+    m_drive.setName("Drive");
+    m_intake.setName("Intake");
+    m_launch.setName("Launch");
+    m_index.setName("Index");
+    m_sensors.setName("Sensors");
+    m_intakeSolenoid.setName("IntakeSolenoid");
+    m_limelight.setName("Limelight");
+
     m_drive.setDefaultCommand(new TankDriveRobot(m_drive, controller1::getLeftY, controller2::getLeftY));
 
     m_autoCommand = new AutonomousCommand(m_launch, m_intakeSolenoid, m_index, m_drive, m_limelight, m_intake);


### PR DESCRIPTION
Per wpilib doc (shuffleboard / advanced-usage) setting the Name
on a subsystem is "The code that is necessary to have subsystems
displayed" on the shuffleboard when the system is in Test mode.