### PR TITLE
No longer invert the rigth side motors - wiring was fixed.

### DIFF
--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -80,7 +80,6 @@ public class Drive extends SubsystemBase {
   public void doInit() {
 
     leftGroup.setInverted(true);
-    rightGroup.setInverted(true);
 
     // PID coefficients
     double kP, kI, kD, kIz, kFF, kMaxOutput, kMinOutput;


### PR DESCRIPTION
It never made sense to me that we were inverting both sides.
We finally realized that the encoder and motor controller cables
on the right side of the robot were swapped.

The right front motor controller was getting feedback from the
right back encoder and vice versa.

Now that that is fixed, they actually do the right thing.