### PR TITLE
Fix c-i. Move to checkout version 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     # Grant execute permission for gradlew
     - name: Grant execute permission for gradlew

--- a/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/SwerveSubsystem.java
@@ -330,7 +330,12 @@ public class SwerveSubsystem extends SubsystemBase {
     xInput = Math.pow(xInput, 3);
     yInput = Math.pow(yInput, 3);
     return swerveDrive.swerveController.getTargetSpeeds(
-        xInput, yInput, headingX, headingY, getHeading().getRadians() * (RobotBase.isReal() ? -1 : 1), maximumSpeed);
+        xInput,
+        yInput,
+        headingX,
+        headingY,
+        getHeading().getRadians() * (RobotBase.isReal() ? -1 : 1),
+        maximumSpeed);
   }
 
   /**


### PR DESCRIPTION
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/